### PR TITLE
ボットの起動/停止/再接続ステータス通知機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,37 @@
 # TelGPT-DiscordBot
 
-discord server で運用している bot です
+discord server で利用している bot です
 
 ## Env
 
-| 環境変数                  | 説明                |
-|-----------------------|-------------------|
-| TEL_GPT_DISCORD_TOKEN | Discord Bot のトークン |
-| TEL_GPT_OPEN_AI_TOKEN | OpenAI の API キー   |
-| TEL_GPT_DEEPL_TOKEN   | DeepL の API キー    |
+| 環境変数名                 | 説明                   |
+|----------------------------|------------------------|
+| TEL_GPT_DISCORD_TOKEN    | Discord Bot のトークン |
+| TEL_GPT_OPEN_AI_TOKEN    | OpenAI の API キー    |
+| TEL_GPT_DEEPL_TOKEN      | DeepL の API キー     |
+| TEL_GPT_GEMINI_TOKEN     | Gemini の API キー    |
+| TEL_GPT_CLAUDE_TOKEN     | Claude の API キー    |
+| TEL_GPT_STATUS_CHANNEL_ID | ステータス通知用チャンネルID |
+
+## 機能
+
+### ステータス通知機能
+
+ボットは以下のタイミングでステータス通知を送信します:
+
+- 起動時
+- 終了時
+- 接続が切断された時
+- 再接続した時
+
+ステータス通知を利用するには:
+
+1. ボットからの通知を受け取るためのテキストチャンネルを作成します
+2. そのチャンネルのIDを取得します（チャンネル名を右クリック→IDをコピー）
+3. `TEL_GPT_STATUS_CHANNEL_ID` 環境変数に取得したIDを設定します
+
+管理者は `/bot-status` コマンドを使って:
+- 現在のボット状態を確認 (`/bot-status action:check`)
+- 手動でステータス通知を送信 (`/bot-status action:notify`)
+
+ができます。

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,43 @@
-from data.configs import botConfig
-from data.discord_command import discordClient
+import asyncio
+import atexit
+import signal
+import sys
 
+from data.configs import botConfig
+from data.discord_command import discordClient, status_channel
+from data.entities.constants import Constants
+
+# シャットダウン時の処理
+def send_shutdown_notification():
+    """ボットのシャットダウン時に通知を送信"""
+    if status_channel:
+        # 非同期関数を同期的に実行するための処理
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # ループが実行中の場合はタスクとして登録
+            loop.create_task(status_channel.send(Constants.bot_stopping_message))
+            # 少し待ってメッセージが送信されるのを待つ
+            loop.run_until_complete(asyncio.sleep(1))
+        else:
+            # ループが実行されていない場合は新しく作成して実行
+            asyncio.run(status_channel.send(Constants.bot_stopping_message))
+
+# シグナルハンドラの設定
+def signal_handler(sig, frame):
+    """シグナル受信時のハンドラ"""
+    print(f"Signal {sig} received, shutting down...")
+    send_shutdown_notification()
+    # クライアントをクローズ
+    if not discordClient.is_closed():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(discordClient.close())
+    sys.exit(0)
+
+# 終了時とシグナル受信時のハンドラを登録
+atexit.register(send_shutdown_notification)
+signal.signal(signal.SIGINT, signal_handler)  # Ctrl+C
+signal.signal(signal.SIGTERM, signal_handler)  # termination
+
+# メインエントリーポイント
 if __name__ == "__main__":
     discordClient.run(token=botConfig.discord_token)

--- a/src/data/configs.py
+++ b/src/data/configs.py
@@ -17,6 +17,7 @@ class BotConfig:
     gemini_api_key: str
     github_pat: str
     claude_api_key: str  # 追加
+    status_channel_id: str  # 追加：ステータス通知チャンネルID
 
     openai_chat_model: OpenAIChatModel
     openai_image_model: OpenAIImageModel
@@ -33,6 +34,10 @@ class BotConfig:
         self.gemini_api_key = os.getenv("TEL_GPT_GEMINI_TOKEN")
         self.github_pat = os.getenv("GITHUB_ISSUE_PAT")
         self.claude_api_key = os.getenv("TEL_GPT_CLAUDE_TOKEN")  # 追加
+        
+        # ステータス通知チャンネルIDの設定（環境変数から取得、未設定の場合はNone）
+        self.status_channel_id = os.getenv("TEL_GPT_STATUS_CHANNEL_ID")
+        
         self.openai_chat_model = OpenAIChatModel.GPT_4_O_MINI
         self.openai_image_model = OpenAIImageModel.DALL_E_3
         self.gemini_chat_model = GeminiChatModel.GEMINI_1_5_FLASH

--- a/src/data/discord_command.py
+++ b/src/data/discord_command.py
@@ -50,7 +50,7 @@ async def on_message(message: discord.Message):
 @discordClient.event
 async def on_disconnect():
     """切断された時のイベントハンドラ"""
-    global status_channel
+    # global status_channelの宣言を削除（読み取りのみの場合は不要）
     if status_channel:
         try:
             # 非同期関数を使用してるためループがないとエラーになる可能性がある
@@ -64,7 +64,7 @@ async def on_disconnect():
 @discordClient.event
 async def on_resumed():
     """再接続した時のイベントハンドラ"""
-    global status_channel
+    # global status_channelの宣言を削除（読み取りのみの場合は不要）
     if status_channel:
         try:
             await status_channel.send(Constants.bot_resumed_message)

--- a/src/data/discord_command.py
+++ b/src/data/discord_command.py
@@ -50,7 +50,6 @@ async def on_message(message: discord.Message):
 @discordClient.event
 async def on_disconnect():
     """切断された時のイベントハンドラ"""
-    # global status_channelの宣言を削除（読み取りのみの場合は不要）
     if status_channel:
         try:
             # 非同期関数を使用してるためループがないとエラーになる可能性がある
@@ -64,7 +63,6 @@ async def on_disconnect():
 @discordClient.event
 async def on_resumed():
     """再接続した時のイベントハンドラ"""
-    # global status_channelの宣言を削除（読み取りのみの場合は不要）
     if status_channel:
         try:
             await status_channel.send(Constants.bot_resumed_message)
@@ -96,7 +94,19 @@ async def bot_status(interaction: discord.Interaction, action: str = "check"):
         try:
             channel_id = int(botConfig.status_channel_id)
             status_channel = discordClient.get_channel(channel_id)
-        except (ValueError, Exception) as e:
+            if not status_channel:
+                await interaction.response.send_message(
+                    f"ステータスチャンネル(ID: {channel_id})が見つかりませんでした。", 
+                    ephemeral=True
+                )
+                return
+        except ValueError:
+            await interaction.response.send_message(
+                f"ステータスチャンネルIDの形式が無効です: {botConfig.status_channel_id}", 
+                ephemeral=True
+            )
+            return
+        except Exception as e:
             await interaction.response.send_message(
                 f"ステータスチャンネルの設定に問題があります: {str(e)}", 
                 ephemeral=True

--- a/src/data/entities/constants.py
+++ b/src/data/entities/constants.py
@@ -7,3 +7,9 @@ class Constants:
 
     # Github Issue 作成のエンドポイント
     create_issue_url: Final[str] = "https://api.github.com/repos/telneko/TelGPT-DiscordBot/issues"
+    
+    # ボットのステータス通知メッセージ
+    bot_started_message: Final[str] = "🟢 TelGPT Bot が起動しました"
+    bot_stopping_message: Final[str] = "🔴 TelGPT Bot を停止しています..."
+    bot_reconnecting_message: Final[str] = "🟡 TelGPT Bot の接続が切断されました。再接続します..."
+    bot_resumed_message: Final[str] = "🟢 TelGPT Bot の接続が復旧しました"


### PR DESCRIPTION
## 概要
ボットの起動や停止、再接続などの状態変化をリアルタイムでDiscordチャンネルに通知する機能を追加しました。これにより、運用者やユーザーはボットの稼働状態を常に把握できるようになります。

## 変更内容
1. **ステータス通知チャンネル設定の追加**
   - 環境変数 `TEL_GPT_STATUS_CHANNEL_ID` を使って通知先を指定できるようにしました
   - 設定がない場合は通常通り動作します（通知なし）

2. **ステータス通知のイベント実装**
   - ボット起動時: 「🟢 TelGPT Bot が起動しました」
   - ボット停止時: 「🔴 TelGPT Bot を停止しています...」
   - 接続切断時: 「🟡 TelGPT Bot の接続が切断されました。再接続します...」
   - 再接続時: 「🟢 TelGPT Bot の接続が復旧しました」

3. **シャットダウン通知機能**
   - Ctrl+C (SIGINT)やDockerの停止コマンド (SIGTERM) などでの終了時にも通知を送信
   - プロセス終了時にはatexit機能を使って確実に通知

4. **管理者用コマンドの追加**
   - `/bot-status action:check` でボットの状態確認
   - `/bot-status action:notify` で手動でステータス通知を送信（テスト用）

## 使用方法
1. ボットのステータス通知を受け取るためのテキストチャンネルを作成
2. そのチャンネルIDを環境変数 `TEL_GPT_STATUS_CHANNEL_ID` に設定
3. ボットを起動すると、指定したチャンネルにステータス通知が送信されます

## 技術的詳細
- Discord.pyのイベントハンドラ (on_ready, on_disconnect, on_resumed) を使って状態変化を検知
- シグナルハンドラ (SIGINT, SIGTERM) とatexitフックを使って終了時の通知を実装

## 懸念点
- 強制終了時（SIGKILL等）では通知されない可能性があります
- 通知チャンネルへの書き込み権限がない場合、エラーログが出力されます（動作は継続）


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: Discordボットのステータス変化をリアルタイムで通知する機能が追加されました。新たな環境変数`TEL_GPT_STATUS_CHANNEL_ID`により、通知先チャンネルを指定可能です。
- New Feature: 管理者用コマンドが追加され、ボットの状態確認や手動でのステータス通知送信が可能になりました。
- Documentation: README.mdが更新され、新機能の使用方法が記載されました。
```

<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->